### PR TITLE
Set platform-specific artifact IDs in Maven publishing for `renlin-ko…

### DIFF
--- a/.github/workflows/deploy-maven-central.yml
+++ b/.github/workflows/deploy-maven-central.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Determine version from branch
         id: version

--- a/gradle-plugin/src/main/kotlin/net/kigawa/renlin/RenlinCompilerPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/net/kigawa/renlin/RenlinCompilerPlugin.kt
@@ -49,7 +49,7 @@ class RenlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
     override fun getPluginArtifact(): SubpluginArtifact {
         return SubpluginArtifact(
             groupId = "net.kigawa.renlin-compiler",
-            artifactId = "renlin-kotlin-plugin",
+            artifactId = "renlin-kotlin-plugin-jvm",
             version = "1.3.0",
         )
     }

--- a/kotlin-plugin/build.gradle.kts
+++ b/kotlin-plugin/build.gradle.kts
@@ -75,8 +75,15 @@ kotlin {
 publishing {
     // Configure all publications
     publications.withType<MavenPublication> {
+        // Set platform-specific artifact IDs to avoid conflicts
+        when (name) {
+            "jvm" -> artifactId = "renlin-kotlin-plugin-jvm"
+            "js" -> artifactId = "renlin-kotlin-plugin-js" 
+            "kotlinMultiplatform" -> artifactId = "renlin-kotlin-plugin"
+            else -> artifactId = "renlin-kotlin-plugin-$name"
+        }
+        
         pom {
-            artifactId = "renlin-kotlin-plugin"
             name.set("net.kigawa.renlin-compiler.gradle.plugin")
             description.set("Kotlin Compiler Plugin for automatic value injection with @AutoFill annotation")
             url.set("https://github.com/Code-Sakura/renlin-compiler")


### PR DESCRIPTION
…tlin-plugin` to avoid conflicts; update build workflow to cache Gradle and adjust plugin artifact ID for JVM.